### PR TITLE
Support Firefox with unprefixed AudioContext

### DIFF
--- a/template/static/js/shared.js
+++ b/template/static/js/shared.js
@@ -1,5 +1,5 @@
 // Start off by initializing a new context.
-context = new webkitAudioContext();
+context = new (window.AudioContext || window.webkitAudioContext)();
 
 // shim layer with setTimeout fallback
 window.requestAnimFrame = (function(){


### PR DESCRIPTION
I was excited to run your examples in Firefox, which in version 23 (now alpha) has partial support for Web Audio. However, it'll only work if you try using unprefixed `AudioContext`, which this patch does.

A possible future change for fuller compatibility would be to replace the MP3 files with Oggs, which both Firefox and Chrome support. When I do so with the [ScriptProcessor node example](http://webaudioapi.com/samples/script-processor/), I get identical results in both browsers.
