### PR TITLE
Feature detect deprecated web audio methods and mouse events

### DIFF
--- a/content/posts/crossfade-playlist/crossfade-playlist-sample.js
+++ b/content/posts/crossfade-playlist/crossfade-playlist-sample.js
@@ -29,7 +29,7 @@ CrossfadePlaylistSample.prototype.play = function() {
 
   function createSource(buffer) {
     var source = context.createBufferSource();
-    var gainNode = context.createGainNode();
+    var gainNode = context.createGain();
     source.buffer = buffer;
     // Connect source to gain.
     source.connect(gainNode);
@@ -64,7 +64,7 @@ CrossfadePlaylistSample.prototype.play = function() {
         gainNode.gain.linearRampToValueAtTime(0, currTime + duration);
 
         // Play the track now.
-        source.start(currTime);
+        source[source.start ? 'start' : 'noteOn'](currTime);
 
         // Increment time for the next iteration.
         currTime += duration - fadeTime;

--- a/content/posts/crossfade/crossfade-sample.js
+++ b/content/posts/crossfade/crossfade-sample.js
@@ -29,14 +29,15 @@ CrossfadeSample.prototype.play = function() {
   // Mute the second source.
   this.ctl1.gainNode.gain.value = 0;
   // Start playback in a loop
-  this.ctl1.source.start(0);
-  this.ctl2.source.start(0);
+  var onName = this.ctl1.source.start ? 'start' : 'noteOn';
+  this.ctl1.source[onName](0);
+  this.ctl2.source[onName](0);
   // Set the initial crossfade to be just source 1.
   this.crossfade(0);
 
   function createSource(buffer) {
     var source = context.createBufferSource();
-    var gainNode = context.createGainNode();
+    var gainNode = context.createGain();
     source.buffer = buffer;
     // Turn on looping
     source.loop = true;
@@ -53,8 +54,9 @@ CrossfadeSample.prototype.play = function() {
 };
 
 CrossfadeSample.prototype.stop = function() {
-  this.ctl1.source.noteOff(0);
-  this.ctl2.source.noteOff(0);
+  var offName = this.ctl1.source.stop ? 'stop' : 'noteOff';
+  this.ctl1.source[offName](0);
+  this.ctl2.source[offName](0);
 };
 
 // Fades between 0 (all source 1) and 1 (all source 2)

--- a/content/posts/filter/filter-sample.js
+++ b/content/posts/filter/filter-sample.js
@@ -34,7 +34,7 @@ FilterSample.prototype.play = function() {
   source.connect(filter);
   filter.connect(context.destination);
   // Play!
-  source.start(0);
+  source[source.start ? 'start' : 'noteOn'](0);
   source.loop = true;
   // Save source and filterNode for later access.
   this.source = source;

--- a/content/posts/frequency-response/frequency-response-sample.js
+++ b/content/posts/frequency-response/frequency-response-sample.js
@@ -2,7 +2,6 @@
 // init() once the page has finished loading.
 window.onload = init;
 
-var context;
 var filter;
 var frequency = 2000;
 var resonance = 5;
@@ -248,7 +247,6 @@ function gainHandler(event, ui) {
 
 
 function initAudio() {
-    context = new webkitAudioContext();
     filter = context.createBiquadFilter();
     filter.Q.value = 5;
     filter.frequency.value = 2000;

--- a/content/posts/frequency-response/index.txt
+++ b/content/posts/frequency-response/index.txt
@@ -12,6 +12,7 @@ description:
   #slider { margin: 10px; }
 </style>
 
+<script src="/static/js/shared.js"></script>
 <script type="text/javascript" src="frequency-response-sample.js"></script>
 
 

--- a/content/posts/metering/metering-sample.js
+++ b/content/posts/metering/metering-sample.js
@@ -31,12 +31,11 @@ MeteringSample.prototype.playPause = function() {
     source.buffer = this.buffer;
     source.loop = true;
     // Run the source node through a gain node.
-    var gain = context.createGainNode();
-    gain.gain.value = this.gainValue;
+    var gain = context.createGain();
     // Create mix node (gain node to combine everything).
-    var mix = context.createGainNode();
+    var mix = context.createGain();
     // Create meter.
-    var meter = context.createJavaScriptNode(2048, 1, 1);
+    var meter = context.createScriptProcessor(2048, 1, 1);
     var ctx = this;
     meter.onaudioprocess = function(e) { ctx.processAudio.call(ctx, e) };
     // Connect the whole sound to mix node.
@@ -50,7 +49,7 @@ MeteringSample.prototype.playPause = function() {
     this.source = source;
     this.gain = gain;
     // Start playback.
-    this.source.start(0);
+    this.source[this.source.start ? 'start' : 'noteOn'](0);
   } else {
     this.source.stop(0);
   }
@@ -91,5 +90,5 @@ MeteringSample.prototype.renderMeter = function() {
   var didRecentlyClip = (new Date() - this.lastClipTime) < 100;
   this.meterElement.className = didRecentlyClip ? 'clip' : 'noclip';
   var ctx = this;
-  webkitRequestAnimationFrame(function() { ctx.renderMeter.call(ctx) });
+  requestAnimFrame(function() { ctx.renderMeter.call(ctx) });
 }

--- a/content/posts/microphone/microphone-sample.js
+++ b/content/posts/microphone/microphone-sample.js
@@ -15,6 +15,10 @@
  */
 
 
+navigator.getUserMedia = (navigator.getUserMedia ||
+                          navigator.webkitGetUserMedia ||
+                          navigator.mozGetUserMedia ||
+                          navigator.msGetUserMedia);
 function MicrophoneSample() {
   this.WIDTH = 640;
   this.HEIGHT = 480;
@@ -23,9 +27,9 @@ function MicrophoneSample() {
 }
 
 MicrophoneSample.prototype.getMicrophoneInput = function() {
-  navigator.webkitGetUserMedia({audio: true},
-                               this.onStream.bind(this),
-                               this.onStreamError.bind(this));
+  navigator.getUserMedia({audio: true},
+                          this.onStream.bind(this),
+                          this.onStreamError.bind(this));
 };
 
 MicrophoneSample.prototype.onStream = function(stream) {

--- a/content/posts/oscillator/index.txt
+++ b/content/posts/oscillator/index.txt
@@ -18,13 +18,13 @@ onchange="sample.changeDetune(this.value);">
 
 <div>
 <input type="radio" name="ir" value="0" class="effect" checked
-onclick="sample.changeType(0)">Sine</input>
+onclick="sample.changeType('sine')">Sine</input>
 <input type="radio" name="ir" value="1" class="effect"
-onclick="sample.changeType(1)">Square</input>
+onclick="sample.changeType('square')">Square</input>
 <input type="radio" name="ir" value="2" class="effect"
-onclick="sample.changeType(2)">Sawtooth</input>
+onclick="sample.changeType('sawtooth')">Sawtooth</input>
 <input type="radio" name="ir" value="3" class="effect"
-onclick="sample.changeType(3)">Triangle</input>
+onclick="sample.changeType('triangle')">Triangle</input>
 </div>
 
 <button onclick="sample.toggle()">Play/pause</button>

--- a/content/posts/oscillator/oscillator-sample.js
+++ b/content/posts/oscillator/oscillator-sample.js
@@ -31,7 +31,7 @@ OscillatorSample.prototype.play = function() {
   this.oscillator.connect(this.analyser);
   this.analyser.connect(context.destination);
 
-  this.oscillator.start(0);
+  this.oscillator[this.oscillator.start ? 'start' : 'noteOn'](0);
 
   requestAnimFrame(this.visualize.bind(this));
 };

--- a/content/posts/procedural/procedural-sample.js
+++ b/content/posts/procedural/procedural-sample.js
@@ -50,7 +50,7 @@ function WhiteNoiseGenerated(callback) {
   this.node = context.createBufferSource();
   this.node.buffer = buffer;
   this.node.loop = true;
-  this.node.start(0);
+  this.node[this.node.start ? 'start' : 'noteOn'](0);
 }
 
 WhiteNoiseGenerated.prototype.connect = function(dest) {
@@ -103,7 +103,7 @@ ProceduralSample.prototype.onLoaded = function() {
     this.voices.push(voice);
   }
 
-  var gainMaster = context.createGainNode();
+  var gainMaster = context.createGain();
   gainMaster.gain.value = 5;
   filter.connect(gainMaster);
 

--- a/content/posts/rapid-sounds/rapid-sounds-sample.js
+++ b/content/posts/rapid-sounds/rapid-sounds-sample.js
@@ -37,14 +37,15 @@ RapidSoundsSample.prototype.shootRound = function(type, rounds, interval, random
   // Make multiple sources using the same buffer and play in quick succession.
   for (var i = 0; i < rounds; i++) {
     var source = this.makeSource(this.buffers[type]);
-    source.playbackRate.value = 1 + Math.random() * random2;
-    source.start(time + i * interval + Math.random() * random);
+    if (random2)
+      source.playbackRate.value = 1 + Math.random() * random2;
+    source[source.start ? 'start' : 'noteOn'](time + i * interval + Math.random() * random);
   }
 }
 
 RapidSoundsSample.prototype.makeSource = function(buffer) {
   var source = context.createBufferSource();
-  var gain = context.createGainNode();
+  var gain = context.createGain();
   gain.gain.value = 0.2;
   source.buffer = buffer;
   source.connect(gain);

--- a/content/posts/room-effects/room-effects-sample.js
+++ b/content/posts/room-effects/room-effects-sample.js
@@ -65,9 +65,9 @@ RoomEffectsSample.prototype.playPause = function() {
     this.source = source;
     this.convolver = convolver;
     // Start playback.
-    this.source.start(0);
+    this.source[this.source.start ? 'start': 'noteOn'](0);
   } else {
-    this.source.stop(0);
+    this.source[this.source.stop ? 'stop': 'noteOff'](0);
   }
   this.isPlaying = !this.isPlaying;
 };

--- a/content/posts/script-processor/script-processor-sample.js
+++ b/content/posts/script-processor/script-processor-sample.js
@@ -41,13 +41,13 @@ ScriptSample.prototype.play = function() {
   processor.connect(context.destination);
 
   console.log('start');
-  source.start(0);
+  source[source.start ? 'start': 'noteOn'](0);
   this.source = source;
 };
 
 ScriptSample.prototype.stop = function() {
   console.log('stop');
-  this.source.stop(0);
+  this.source[this.source.stop ? 'stop': 'noteOff'](0);
 };
 
 ScriptSample.prototype.onProcess = function(e) {

--- a/content/posts/spatialized/spatialized-sample.js
+++ b/content/posts/spatialized/spatialized-sample.js
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+var wheelEvent = 'onwheel' in document.createElement('div') ? 'wheel' :
+                 document.onmousewheel !== undefined ? 'mousewheel' : 'DOMMouseScroll';
+
 
 // Draws a canvas and tracks mouse click/drags on the canvas.
 function Field(canvas) {
@@ -35,7 +38,7 @@ function Field(canvas) {
   canvas.addEventListener('mousemove', function() {
     obj.handleMouseMove.apply(obj, arguments)
   });
-  canvas.addEventListener('mousewheel', function() {
+  canvas.addEventListener(wheelEvent, function() {
     obj.handleMouseWheel.apply(obj, arguments);
   });
   // Setup keyboard listener
@@ -95,7 +98,10 @@ Field.prototype.handleMouseOut = function(e) {
 Field.prototype.handleMouseMove = function(e) {
   if (this.isMouseInside) {
     // Update the position.
-    this.point = {x: e.offsetX, y: e.offsetY};
+    this.point = {
+      x: e.offsetX == undefined ? (e.layerX - e.currentTarget.offsetLeft) : e.offsetX,
+      y: e.offsetY == undefined ? (e.layerY - e.currentTarget.offsetTop) : e.offsetY
+    };
     // Re-render the canvas.
     this.render();
     // Callback.
@@ -118,7 +124,8 @@ Field.prototype.handleKeyDown = function(e) {
 
 Field.prototype.handleMouseWheel = function(e) {
   e.preventDefault();
-  this.changeAngleHelper(e.wheelDelta/500);
+  var delta = e.wheelDelta || (e.deltaY * -1200);
+  this.changeAngleHelper(delta/500);
 };
 
 Field.prototype.changeAngleHelper = function(delta) {
@@ -178,7 +185,7 @@ SpatializedSample.prototype.play = function() {
   // direction.
   panner.connect(context.destination);
   source.connect(panner);
-  source.start(0);
+  source[source.start ? 'start': 'noteOn'](0);
   // Position the listener at the origin.
   context.listener.setPosition(0, 0, 0);
   foo = panner;
@@ -190,7 +197,7 @@ SpatializedSample.prototype.play = function() {
 }
 
 SpatializedSample.prototype.stop = function() {
-  this.source.stop(0);
+  this.source[this.source.stop ? 'stop': 'noteOff'](0);
   this.isPlaying = false;
 }
 

--- a/content/posts/value-curve/value-curve-sample.js
+++ b/content/posts/value-curve/value-curve-sample.js
@@ -27,7 +27,7 @@ function ValueCurveSample() {
 };
 
 ValueCurveSample.prototype.play = function() {
-  this.gainNode = context.createGainNode();
+  this.gainNode = context.createGain();
   this.source = context.createBufferSource();
   this.source.buffer = this.buffer;
 
@@ -38,7 +38,7 @@ ValueCurveSample.prototype.play = function() {
   this.gainNode.gain.value = 0.3;
   // Start playback in a loop
   this.source.loop = true;
-  this.source.start(0);
+  this.source[this.source.start ? 'start': 'noteOn'](0);
 };
 
 ValueCurveSample.prototype.setValueCurve = function(element) {
@@ -69,12 +69,12 @@ ValueCurveSample.prototype.setLFO = function() {
   //osc.connect(this.source.playbackRate);
 
   // Start immediately, and stop in 2 seconds.
-  osc.start(0);
-  osc.stop(context.currentTime + this.duration);
+  osc[osc.start ? 'start': 'noteOn'](0);
+  osc[osc.stop ? 'stop': 'noteOff'](context.currentTime + this.duration);
 };
 
 ValueCurveSample.prototype.stop = function() {
-  this.source.stop(0);
+  this.source[this.source.stop ? 'stop': 'noteOff'](0);
 };
 
 ValueCurveSample.prototype.toggle = function() {

--- a/content/posts/visualizer/visualizer-sample.js
+++ b/content/posts/visualizer/visualizer-sample.js
@@ -44,7 +44,7 @@ function VisualizerSample() {
 VisualizerSample.prototype.togglePlayback = function() {
   if (this.isPlaying) {
     // Stop playback
-    this.source.noteOff(0);
+    this.source[this.source.stop ? 'stop': 'noteOff'](0);
     this.startOffset += context.currentTime - this.startTime;
     console.log('paused at', this.startOffset);
     // Save the position of the play head.
@@ -57,7 +57,7 @@ VisualizerSample.prototype.togglePlayback = function() {
     this.source.buffer = this.buffer;
     this.source.loop = true;
     // Start playback, but make sure we stay in bound of the buffer.
-    this.source.start(0, this.startOffset % this.buffer.duration);
+    this.source[this.source.start ? 'start' : 'noteOn'](0, this.startOffset % this.buffer.duration);
     // Start visualizer.
     requestAnimFrame(this.draw.bind(this));
   }

--- a/content/posts/volume/volume-sample.js
+++ b/content/posts/volume/volume-sample.js
@@ -23,7 +23,7 @@ function VolumeSample() {
 };
 
 VolumeSample.prototype.play = function() {
-  this.gainNode = context.createGainNode();
+  this.gainNode = context.createGain();
   this.source = context.createBufferSource();
   this.source.buffer = this.buffer;
 
@@ -33,7 +33,7 @@ VolumeSample.prototype.play = function() {
   this.gainNode.connect(context.destination);
   // Start playback in a loop
   this.source.loop = true;
-  this.source.start(0);
+  this.source[this.source.start ? 'start' : 'noteOn'](0);
 };
 
 VolumeSample.prototype.changeVolume = function(element) {
@@ -45,7 +45,7 @@ VolumeSample.prototype.changeVolume = function(element) {
 };
 
 VolumeSample.prototype.stop = function() {
-  this.source.stop(0);
+  this.source[this.source.stop ? 'stop' : 'noteOff'](0);
 };
 
 VolumeSample.prototype.toggle = function() {

--- a/template/static/js/shared.js
+++ b/template/static/js/shared.js
@@ -1,6 +1,13 @@
 // Start off by initializing a new context.
 context = new (window.AudioContext || window.webkitAudioContext)();
 
+if (!context.createGain)
+  context.createGain = context.createGainNode;
+if (!context.createDelay)
+  context.createDelay = context.createDelayNode;
+if (!context.createScriptProcessor)
+  context.createScriptProcessor = context.createJavaScriptNode;
+
 // shim layer with setTimeout fallback
 window.requestAnimFrame = (function(){
 return  window.requestAnimationFrame       || 
@@ -18,7 +25,7 @@ function playSound(buffer, time) {
   var source = context.createBufferSource();
   source.buffer = buffer;
   source.connect(context.destination);
-  source.start(time);
+  source[source.start ? 'start' : 'noteOn'](time);
 }
 
 function loadSounds(obj, soundMap, callback) {


### PR DESCRIPTION
- Use non-deprecated node creation methods, falling back to deprecated (delay, gain, processor)
- Detect node methods like start/noteOn, stop/noteOff to use appropriate method, but non-deprecated where possible
- Use `shared` file's context in all files
- Set Oscillator's type via string rather than number
- Fix instances where setting a non number value to an AudioParam's value which would appropriate fail in Firefox
- Use appropriate `requestAnimationFrame` for x-browsers
- Use appropriate `getUserMedia` for x-browsers
-  Use x-browser wheel/mouse events for spatialized example
