### PR TITLE
Fix for web audio policy restrictions

### DIFF
--- a/template/base.html
+++ b/template/base.html
@@ -11,6 +11,8 @@
 
 <div id="container">
 
+  <div id="overlay">Click to play</div>
+
   <div id="nav">
     <ul>
       <li><a href="/samples">Samples</a>

--- a/template/static/js/shared.js
+++ b/template/static/js/shared.js
@@ -1,6 +1,16 @@
 // Start off by initializing a new context.
 context = new (window.AudioContext || window.webkitAudioContext)();
 
+if (context.state === 'suspended') {
+  const overlay = document.getElementById('overlay');
+  overlay.className = 'visible';
+  document.addEventListener('click', () => {
+    context.resume().then(() => {
+      overlay.className = 'hidden';
+    });
+  }, {once: true});
+}
+
 if (!context.createGain)
   context.createGain = context.createGainNode;
 if (!context.createDelay)

--- a/template/static/style.css
+++ b/template/static/style.css
@@ -100,11 +100,12 @@ blockquote {
   top: 0;
   left: 0;
   background: rgba(0, 0, 0, 80%);
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   display: none;
   justify-content: center;
   padding-top: 15em;
+  box-sizing: border-box;
 }
 #overlay.visible {
   display: flex;

--- a/template/static/style.css
+++ b/template/static/style.css
@@ -93,3 +93,19 @@ input[type="checkbox"]:checked + label span {
 blockquote {
   font-style: italic;
 }
+
+#overlay {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 80%);
+  width: 100vw;
+  height: 100vh;
+  display: none;
+  justify-content: center;
+  padding-top: 15em;
+}
+#overlay.visible {
+  display: flex;
+}


### PR DESCRIPTION
Adds an overlay to the samples that accounts for the stricter audio playback policies in the latest versions of browsers. This fix is especially important for Safari, since it requires an explicit resume of the audio context before it plays anything at all.

Here's what the overlay looks like:
![image](https://user-images.githubusercontent.com/79419/126078735-b629ce4e-63ae-4949-aed1-0fb1438e66e5.png)
